### PR TITLE
malloc, calloc and realloc restructred

### DIFF
--- a/src/dbm/dbm_distribution.c
+++ b/src/dbm/dbm_distribution.c
@@ -15,6 +15,7 @@
 
 #include "dbm_distribution.h"
 #include "dbm_hyperparams.h"
+#include "dbm_mempool.h"
 
 /*******************************************************************************
  * \brief Private routine for creating a new one dimensional distribution.
@@ -28,7 +29,7 @@ static void dbm_dist_1d_new(dbm_dist_1d_t *dist, const int length,
   dist->my_rank = dbm_mpi_comm_rank(comm);
   dist->nranks = dbm_mpi_comm_size(comm);
   dist->length = length;
-  dist->index2coord = malloc(length * sizeof(int));
+  dist->index2coord = dbm_mem_alloc<int*>(length * sizeof(int));
   memcpy(dist->index2coord, coords, length * sizeof(int));
 
   // Check that cart coordinates and ranks are equivalent.
@@ -46,7 +47,7 @@ static void dbm_dist_1d_new(dbm_dist_1d_t *dist, const int length,
   }
 
   // Store local rows/columns.
-  dist->local_indicies = malloc(dist->nlocals * sizeof(int));
+  dist->local_indicies = dbm_mem_alloc<int*>(dist->nlocals * sizeof(int));
   int j = 0;
   for (int i = 0; i < length; i++) {
     if (coords[i] == dist->my_rank) {
@@ -105,7 +106,7 @@ void dbm_distribution_new(dbm_distribution_t **dist_out, const int fortran_comm,
                           const int row_dist[nrows],
                           const int col_dist[ncols]) {
   assert(omp_get_num_threads() == 1);
-  dbm_distribution_t *dist = calloc(1, sizeof(dbm_distribution_t));
+  dbm_distribution_t *dist = dbm_mem_calloc<dbm_distribution_t*>(1, sizeof(dbm_distribution_t));
   dist->ref_count = 1;
 
   dist->comm = dbm_mpi_comm_f2c(fortran_comm);

--- a/src/dbm/dbm_library.c
+++ b/src/dbm/dbm_library.c
@@ -40,7 +40,7 @@ void dbm_library_init(void) {
   }
 
   max_threads = omp_get_max_threads();
-  per_thread_counters = malloc(max_threads * sizeof(int64_t *));
+  per_thread_counters = dbm_mem_alloc<int64_t**>(max_threads * sizeof(int64_t *));
 
   // Using parallel regions to ensure memory is allocated near a thread's core.
 #pragma omp parallel default(none) shared(per_thread_counters)                 \
@@ -48,7 +48,7 @@ void dbm_library_init(void) {
   {
     const int ithread = omp_get_thread_num();
     const size_t counters_size = DBM_NUM_COUNTERS * sizeof(int64_t);
-    per_thread_counters[ithread] = malloc(counters_size);
+    per_thread_counters[ithread] = dbm_mem_alloc<int64_t*>(counters_size);
     memset(per_thread_counters[ithread], 0, counters_size);
   }
 

--- a/src/dbm/dbm_mempool.c
+++ b/src/dbm/dbm_mempool.c
@@ -34,7 +34,7 @@ static void *actual_malloc(const size_t size, const bool on_device) {
   (void)on_device; // mark used
 #endif
 
-  void *memory = malloc(size);
+  void *memory = dbm_mem_alloc<void*>(size);
   assert(memory != NULL);
   return memory;
 }
@@ -113,7 +113,7 @@ static void *internal_mempool_malloc(const size_t size, const bool on_device) {
 
     // If no chunk was found, allocate a new one.
     if (chunk == NULL) {
-      chunk = malloc(sizeof(dbm_memchunk_t));
+      chunk = dbm_mem_alloc<dbm_memchunk_t*>(sizeof(dbm_memchunk_t));
       chunk->on_device = on_device;
       chunk->size = 0;
       chunk->mem = NULL;

--- a/src/dbm/dbm_mempool.h
+++ b/src/dbm/dbm_mempool.h
@@ -41,6 +41,33 @@ void dbm_mempool_clear(void);
 }
 #endif
 
+
+/*******************************************************************************
+ * \A small wrapper around malloc's to return the pointer with the typecast.
+ * \author Rahul Gayatri
+ ******************************************************************************/
+#ifdef __cplusplus
+
+template<class DataType>
+DataType dbm_mem_alloc(size_t N)
+{
+  return((DataType)malloc(N));
+}
+
+template<class DataType>
+DataType dbm_mem_calloc(size_t nitems, size_t N)
+{
+  return((DataType)calloc(nitems, N));
+}
+
+template<class DataType>
+DataType dbm_mem_realloc(void* ptr, size_t N)
+{
+  return((DataType)realloc(ptr, N));
+}
+
+#endif
+
 #endif
 
 // EOF

--- a/src/dbm/dbm_miniapp.c
+++ b/src/dbm/dbm_miniapp.c
@@ -20,6 +20,7 @@
 #include "dbm_library.h"
 #include "dbm_matrix.h"
 #include "dbm_mpi.h"
+#include "dbm_mempool.h"
 
 /*******************************************************************************
  * \brief Wrapper for printf, passed to dbm_library_print_stats.
@@ -48,8 +49,8 @@ static dbm_matrix_t *create_some_matrix(const int nrows, const int ncols,
   dbm_mpi_cart_get(comm, 2, cart_dims, cart_periods, cart_coords);
 
   // Create distribution.
-  int *row_dist = malloc(nrows * sizeof(int));
-  int *col_dist = malloc(ncols * sizeof(int));
+  int *row_dist = dbm_mem_alloc<int*>(nrows * sizeof(int));
+  int *col_dist = dbm_mem_alloc<int*>(ncols * sizeof(int));
   for (int i = 0; i < nrows; i++) {
     row_dist[i] = i % cart_dims[0];
   }
@@ -63,8 +64,8 @@ static dbm_matrix_t *create_some_matrix(const int nrows, const int ncols,
   free(col_dist);
 
   // Create matrix.
-  int *row_sizes = malloc(nrows * sizeof(int));
-  int *col_sizes = malloc(ncols * sizeof(int));
+  int *row_sizes = dbm_mem_alloc<int*>(nrows * sizeof(int));
+  int *col_sizes = dbm_mem_alloc<int*>(ncols * sizeof(int));
   for (int i = 0; i < nrows; i++) {
     row_sizes[i] = row_size;
   }
@@ -101,8 +102,8 @@ static void reserve_all_blocks(dbm_matrix_t *matrix) {
         }
       }
     }
-    int *reserve_row = malloc(nblocks * sizeof(int));
-    int *reserve_col = malloc(nblocks * sizeof(int));
+    int *reserve_row = dbm_mem_alloc<int*>(nblocks * sizeof(int));
+    int *reserve_col = dbm_mem_alloc<int*>(nblocks * sizeof(int));
     int iblock = 0;
 #pragma omp for collapse(2)
     for (int row = 0; row < nrows; row++) {

--- a/src/dbm/dbm_mpi.c
+++ b/src/dbm/dbm_mpi.c
@@ -11,6 +11,7 @@
 #include <string.h>
 
 #include "dbm_mpi.h"
+#include "dbm_mempool.h"
 
 #if defined(__parallel)
 /*******************************************************************************
@@ -237,7 +238,7 @@ bool dbm_mpi_comms_are_similar(const dbm_mpi_comm_t comm1,
  ******************************************************************************/
 void dbm_mpi_max_int(int *values, const int count, const dbm_mpi_comm_t comm) {
 #if defined(__parallel)
-  int *recvbuf = malloc(count * sizeof(int));
+  int *recvbuf = dbm_mem_alloc<int*>(count * sizeof(int));
   CHECK(MPI_Allreduce(values, recvbuf, count, MPI_INT, MPI_MAX, comm));
   memcpy(values, recvbuf, count * sizeof(int));
   free(recvbuf);
@@ -255,7 +256,7 @@ void dbm_mpi_max_int(int *values, const int count, const dbm_mpi_comm_t comm) {
 void dbm_mpi_max_double(double *values, const int count,
                         const dbm_mpi_comm_t comm) {
 #if defined(__parallel)
-  double *recvbuf = malloc(count * sizeof(double));
+  double *recvbuf = dbm_mem_alloc<double*>(count * sizeof(double));
   CHECK(MPI_Allreduce(values, recvbuf, count, MPI_DOUBLE, MPI_MAX, comm));
   memcpy(values, recvbuf, count * sizeof(double));
   free(recvbuf);
@@ -272,7 +273,7 @@ void dbm_mpi_max_double(double *values, const int count,
  ******************************************************************************/
 void dbm_mpi_sum_int(int *values, const int count, const dbm_mpi_comm_t comm) {
 #if defined(__parallel)
-  int *recvbuf = malloc(count * sizeof(int));
+  int *recvbuf = dbm_mem_alloc<int*>(count * sizeof(int));
   CHECK(MPI_Allreduce(values, recvbuf, count, MPI_INT, MPI_SUM, comm));
   memcpy(values, recvbuf, count * sizeof(int));
   free(recvbuf);
@@ -290,7 +291,7 @@ void dbm_mpi_sum_int(int *values, const int count, const dbm_mpi_comm_t comm) {
 void dbm_mpi_sum_int64(int64_t *values, const int count,
                        const dbm_mpi_comm_t comm) {
 #if defined(__parallel)
-  int64_t *recvbuf = malloc(count * sizeof(int64_t));
+  int64_t *recvbuf = dbm_mem_alloc<int64_t*>(count * sizeof(int64_t));
   CHECK(MPI_Allreduce(values, recvbuf, count, MPI_INT64_T, MPI_SUM, comm));
   memcpy(values, recvbuf, count * sizeof(int64_t));
   free(recvbuf);
@@ -308,7 +309,7 @@ void dbm_mpi_sum_int64(int64_t *values, const int count,
 void dbm_mpi_sum_double(double *values, const int count,
                         const dbm_mpi_comm_t comm) {
 #if defined(__parallel)
-  double *recvbuf = malloc(count * sizeof(double));
+  double *recvbuf = dbm_mem_alloc<double*>(count * sizeof(double));
   CHECK(MPI_Allreduce(values, recvbuf, count, MPI_DOUBLE, MPI_SUM, comm));
   memcpy(values, recvbuf, count * sizeof(double));
   free(recvbuf);

--- a/src/dbm/dbm_multiply.c
+++ b/src/dbm/dbm_multiply.c
@@ -17,6 +17,7 @@
 #include "dbm_multiply_cpu.h"
 #include "dbm_multiply_gpu.h"
 #include "dbm_multiply_internal.h"
+#include "dbm_mempool.h"
 
 /*******************************************************************************
  * \brief Returns the larger of two given integer (missing from the C standard)
@@ -31,8 +32,8 @@ static inline int imax(int x, int y) { return (x > y ? x : y); }
 static float *compute_rows_max_eps(const bool trans, const dbm_matrix_t *matrix,
                                    const double filter_eps) {
   const int nrows = (trans) ? matrix->ncols : matrix->nrows;
-  int *nblocks_per_row = calloc(nrows, sizeof(int));
-  float *row_max_eps = malloc(nrows * sizeof(float));
+  int *nblocks_per_row = dbm_mem_calloc<int*>(nrows, sizeof(int));
+  float *row_max_eps = dbm_mem_alloc<float*>(nrows * sizeof(float));
 
 #pragma omp parallel
   {
@@ -76,7 +77,7 @@ typedef struct {
  * \author Ole Schuett
  ******************************************************************************/
 static backend_context_t *backend_start(const dbm_matrix_t *matrix_c) {
-  backend_context_t *ctx = calloc(1, sizeof(backend_context_t));
+  backend_context_t *ctx = dbm_mem_calloc<backend_context_t*>(1, sizeof(backend_context_t));
 
 #if defined(__OFFLOAD) && !defined(__NO_OFFLOAD_DBM)
   dbm_multiply_gpu_start(MAX_BATCH_SIZE, dbm_get_num_shards(matrix_c),

--- a/src/dbm/dbm_multiply_gpu.c
+++ b/src/dbm/dbm_multiply_gpu.c
@@ -38,7 +38,7 @@ void dbm_multiply_gpu_start(const int max_batch_size, const int nshards,
 
   // Allocate and upload shards of result matrix C.
   ctx->shards_c_dev =
-      (dbm_shard_gpu_t *)malloc(nshards * sizeof(dbm_shard_gpu_t));
+      dbm_mem_alloc<dbm_shard_gpu_t *>(nshards * sizeof(dbm_shard_gpu_t));
   for (int i = 0; i < nshards; i++) {
     offloadStreamCreate(&ctx->shards_c_dev[i].stream);
     ctx->shards_c_dev[i].data_size = ctx->shards_c_host[i].data_size;

--- a/src/dbm/dbm_shard.c
+++ b/src/dbm/dbm_shard.c
@@ -13,6 +13,7 @@
 
 #include "dbm_hyperparams.h"
 #include "dbm_shard.h"
+#include "dbm_mempool.h"
 
 /*******************************************************************************
  * \brief Internal routine for finding a power of two greater than given number.
@@ -53,7 +54,7 @@ static void hashtable_init(dbm_shard_t *shard) {
       next_power2(HASHTABLE_FACTOR * shard->nblocks_allocated);
   shard->hashtable_mask = shard->hashtable_size - 1;
   shard->hashtable_prime = next_prime(shard->hashtable_size);
-  shard->hashtable = calloc(shard->hashtable_size, sizeof(int));
+  shard->hashtable = dbm_mem_calloc<int*>(shard->hashtable_size, sizeof(int));
 }
 
 /*******************************************************************************
@@ -63,12 +64,12 @@ static void hashtable_init(dbm_shard_t *shard) {
 void dbm_shard_init(dbm_shard_t *shard) {
   shard->nblocks = 0;
   shard->nblocks_allocated = INITIAL_NBLOCKS_ALLOCATED;
-  shard->blocks = malloc(shard->nblocks_allocated * sizeof(dbm_block_t));
+  shard->blocks = dbm_mem_alloc<dbm_block_t*>(shard->nblocks_allocated * sizeof(dbm_block_t));
   hashtable_init(shard);
   shard->data_size = 0;
   shard->data_promised = 0;
   shard->data_allocated = INITIAL_DATA_ALLOCATED;
-  shard->data = malloc(shard->data_allocated * sizeof(double));
+  shard->data = dbm_mem_alloc<double*>(shard->data_allocated * sizeof(double));
 
   omp_init_lock(&shard->lock);
 }
@@ -81,7 +82,7 @@ void dbm_shard_copy(dbm_shard_t *shard_a, const dbm_shard_t *shard_b) {
   free(shard_a->blocks);
   shard_a->nblocks = shard_b->nblocks;
   shard_a->nblocks_allocated = shard_b->nblocks_allocated;
-  shard_a->blocks = malloc(shard_b->nblocks_allocated * sizeof(dbm_block_t));
+  shard_a->blocks = dbm_mem_alloc<dbm_block_t*>(shard_b->nblocks_allocated * sizeof(dbm_block_t));
   memcpy(shard_a->blocks, shard_b->blocks,
          shard_b->nblocks * sizeof(dbm_block_t));
 
@@ -89,13 +90,13 @@ void dbm_shard_copy(dbm_shard_t *shard_a, const dbm_shard_t *shard_b) {
   shard_a->hashtable_size = shard_b->hashtable_size;
   shard_a->hashtable_mask = shard_b->hashtable_mask;
   shard_a->hashtable_prime = shard_b->hashtable_prime;
-  shard_a->hashtable = malloc(shard_b->hashtable_size * sizeof(int));
+  shard_a->hashtable = dbm_mem_alloc<int*>(shard_b->hashtable_size * sizeof(int));
   memcpy(shard_a->hashtable, shard_b->hashtable,
          shard_b->hashtable_size * sizeof(int));
 
   free(shard_a->data);
   shard_a->data_allocated = shard_b->data_allocated;
-  shard_a->data = malloc(shard_b->data_allocated * sizeof(double));
+  shard_a->data = dbm_mem_alloc<double*>(shard_b->data_allocated * sizeof(double));
   shard_a->data_size = shard_b->data_size;
   memcpy(shard_a->data, shard_b->data, shard_b->data_size * sizeof(double));
 }
@@ -174,7 +175,7 @@ dbm_block_t *dbm_shard_promise_new_block(dbm_shard_t *shard, const int row,
   if (shard->nblocks_allocated < shard->nblocks + 1) {
     shard->nblocks_allocated = ALLOCATION_FACTOR * (shard->nblocks + 1);
     shard->blocks =
-        realloc(shard->blocks, shard->nblocks_allocated * sizeof(dbm_block_t));
+        dbm_mem_realloc<dbm_block_t*>((void*)shard->blocks, shard->nblocks_allocated * sizeof(dbm_block_t));
 
     // rebuild hashtable
     free(shard->hashtable);
@@ -205,7 +206,7 @@ void dbm_shard_allocate_promised_blocks(dbm_shard_t *shard) {
   // Reallocate data array if nessecary.
   if (shard->data_promised > shard->data_allocated) {
     shard->data_allocated = ALLOCATION_FACTOR * shard->data_promised;
-    shard->data = realloc(shard->data, shard->data_allocated * sizeof(double));
+    shard->data = dbm_mem_realloc<double*>((void*)shard->data, shard->data_allocated * sizeof(double));
   }
 
   // Zero new blocks.


### PR DESCRIPTION
The code was not typecasting the memory allocators explicitly and was instead relying on compilers to do the job. 
This PR fixes the issue.

